### PR TITLE
Add distinct for Queries #569

### DIFF
--- a/controllers/tables.go
+++ b/controllers/tables.go
@@ -125,6 +125,16 @@ func SelectFromTables(w http.ResponseWriter, r *http.Request) {
 	}
 	query := config.PrestConf.Adapter.SelectSQL(selectStr, database, schema, table)
 
+	distinct, err := config.PrestConf.Adapter.DistinctClause(r)
+	if err != nil {
+		err = fmt.Errorf("could not perform Distinct: %v", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if distinct != "" {
+		query = strings.Replace(query, "SELECT", distinct, 1)
+	}
+
 	countQuery, err := config.PrestConf.Adapter.CountByRequest(r)
 	if err != nil {
 		err = fmt.Errorf("could not perform CountByRequest: %v", err)

--- a/docs/getting-started/installation.en.md
+++ b/docs/getting-started/installation.en.md
@@ -32,7 +32,7 @@ docker pull prest/prest:v1
 ### Using go install
 
 ```sh
-go install github.com/prest/prest/cmd/prestd
+go install github.com/prest/prest/cmd/prestd@latest
 ```
 
 ### With Homebrew

--- a/docs/query-statements/_index.en.md
+++ b/docs/query-statements/_index.en.md
@@ -73,7 +73,7 @@ GET /DATABASE/SCHEMA/TABLE?FIELD=$eq.VALUE
 | ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `?_select={field name 1},{fiel name 2}`  | Limit fields list on result - sql ansii standard                                                                                                               |
 | `?_count={field name}`                   | Count per field - `*` representation all fields                                                                                                                |
-| `?_render=xml`                           | Set API render syntax - default is `json`                                                                                                                      |
+| `?_renderer=xml`                         | Set API render syntax, supported: `json` (default), `xml`                                                                                                            |
 | `?page={set page number}`                | Navigation on return pages with large volume of data                                                                                                           |
 | `?page_size={number to return by pages}` | 10 is default number                                                                                                                                           |
 | `?_distinct=true`                         | `DISTINCT` clause with SELECT                                                                                                                                  |


### PR DESCRIPTION
This addresses issue #569. I checked the code and noticed that the distinct parameter is not checked for queries, only for fetching metadata from the DB, where it doesn't make sense because there are never multiple databases, schemas or tables with the same name.

I tested it locally and it seems to work fine. What do you think @avelino?